### PR TITLE
abe - ansible rpm in repo

### DIFF
--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -136,23 +136,18 @@
       when: offline
       tags: repo
 
-    - name: Determine name of custom Ansible RPM file
-      shell: ls ~/ansible/rpm-build/ansible-*.noarch.rpm
-      register: ansible_rpm
-      when: offline
-      tags: repo
-
     - name: Download the Ansible dependent RPMs when offline
       shell: repotrack "{{ item }}" -p "{{ rpm_path }}"
       ignore_errors: yes
-      with_items: ansible_rpm.stdout
+      with_fileglob: ~/ansible/rpm-build/ansible-*.noarch.rpm
+      when: offline
       tags: repo
 
     - name: Copy the Ansible RPM to /opt/autodeploy/resources/rpms when offline
       copy:
         src: "{{ item }}"
         dest: "{{ rpm_path }}"
-      with_items: ansible_rpm.stdout
+      with_fileglob: ~/ansible/rpm-build/ansible-*.noarch.rpm
       when: offline
       tags: repo
 

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -136,6 +136,26 @@
       when: offline
       tags: repo
 
+    - name: Determine name of custom Ansible RPM file
+      shell: ls ~/ansible/rpm-build/ansible-*.noarch.rpm
+      register: ansible_rpm
+      when: offline
+      tags: repo
+
+    - name: Download the Ansible dependent RPMs when offline
+      shell: repotrack "{{ item }}" -p "{{ rpm_path }}"
+      ignore_errors: yes
+      with_items: ansible_rpm.stdout
+      tags: repo
+
+    - name: Copy the Ansible RPM to /opt/autodeploy/resources/rpms when offline
+      copy:
+        src: "{{ item }}"
+        dest: "{{ rpm_path }}"
+      with_items: ansible_rpm.stdout
+      when: offline
+      tags: repo
+
     - name: Create the local repository in /opt/autodeploy/resources/rpms when offline
       command: createrepo "{{ rpm_path }}"
       when: offline


### PR DESCRIPTION
This PR is for temporary changes to the stage_resources.yml needed until Ansible 2.x is included in epel. It does the following:
1. Find the name of the Ansible RPM built by deploy script
2. Download any new dependencies for this RPM if any, if there aren't any repotrack errors with a warning that we ignore
3. Copy the Ansible RPM to the /opt/autodeploy/resources/rpms directory

```
PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Download the EPEL RPMs to /opt/autodeploy/resources/rpms when offline] ***
changed: [localhost]

TASK [Download the Red Hat RPMs to /opt/autodeploy/resources/rpms when offline]
changed: [localhost]

TASK [Determine name of custom Ansible RPM file] *******************************
changed: [localhost]

TASK [Download the Ansible dependent RPMs when offline] ************************
failed: [localhost] => (item=/root/ansible/rpm-build/ansible-2.0.1.0-0.git201601282137.870a4b8.HEAD.el7.noarch.rpm) => {"changed": true, "cmd": "repotrack \"/root/ansible/rpm-build/ansible-2.0.1.0-0.git201601282137.870a4b8.HEAD.el7.noarch.rpm\" -p \"/opt/autodeploy/resources/rpms/\"", "delta": "0:00:01.598420", "end": "2016-02-22 13:23:33.934269", "failed": true, "item": "/root/ansible/rpm-build/ansible-2.0.1.0-0.git201601282137.870a4b8.HEAD.el7.noarch.rpm", "rc": 1, "start": "2016-02-22 13:23:32.335849", "stderr": "Nothing found to download matching packages specified", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring

TASK [Copy the Ansible RPM to /opt/autodeploy/resources/rpms when offline] *****
changed: [localhost] => (item=/root/ansible/rpm-build/ansible-2.0.1.0-0.git201601282137.870a4b8.HEAD.el7.noarch.rpm)

TASK [Create the local repository in /opt/autodeploy/resources/rpms when offline] ***
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=5    unreachable=0    failed=0
```