### PR TITLE
Changes pip install to use relative paths

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -9,17 +9,19 @@
 
 - name: Install required pip-based support packages (Online)
   pip:
-    requirements: "{{ projects_base_path }}/dcaf-abe/ansible/files/pip-requirements.txt"
+    requirements: "{{ item }}" 
     state: present
     extra_args: "--upgrade"
   when: not offline
+  with_fileglob: "files/*pip-requirements*"
 
 - name: Install required pip-based support packages (Offline)
   pip:
-    requirements: "{{ projects_base_path }}/dcaf-abe/ansible/files/pip-requirements.txt"
+    requirements: "{{ item }}"
     state: present
     extra_args: "--index-url=file://{{ packages_path }}simple/"
   when: offline
+  with_fileglob: "files/*pip-requirements*"
 
 - name: Create the .ssh directory
   file:

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -13,7 +13,7 @@
     state: present
     extra_args: "--upgrade"
   when: not offline
-  with_fileglob: "files/*pip-requirements*"
+  with_fileglob: "../../files/*pip-requirements*"
 
 - name: Install required pip-based support packages (Offline)
   pip:
@@ -21,7 +21,7 @@
     state: present
     extra_args: "--index-url=file://{{ packages_path }}simple/"
   when: offline
-  with_fileglob: "files/*pip-requirements*"
+  with_fileglob: "../../files/*pip-requirements*"
 
 - name: Create the .ssh directory
   file:

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -18,10 +18,11 @@
 
     - name: Install required pip-based support packages
       pip:
-        requirements: "{{ projects_base_path }}/dcaf-abe/ansible/files/pip-requirements.txt"
+        requirements: "{{ item }}"
         state: present
         extra_args: "--upgrade"
       tags: pkgs
+      with_fileglob: "files/*pip-requirements*"
 
     - name: Create the staging directories in /opt/autodeploy
       file:
@@ -148,8 +149,10 @@
       tags: docker
 
     - name: Mirror pip dependencies to /opt/autodeploy/resources/packages when offline
-      command: pip2tgz {{ packages_path }} -r {{ projects_base_path }}/dcaf-abe/ansible/files/pip-requirements.txt
+      command: pip2tgz {{ packages_path }} -r {{ item }} 
       when: offline and not (docker_py.stat.exists)
+      with_fileglob: "files/*pip-requirements*"
+      
 
     - name: Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages
       stat:


### PR DESCRIPTION
Resolves an issue if plays were not ran out of the `/opt/autodeploy/projects` directory.


```bash 
⚡ root@piptest1  /opt/autodeploy/projects/dcaf-abe/ansible  ➦ 856fff2  ansible-playbook stage_resources.yml --extra-vars "github_key_file=~/github.pem rhn_user=$RHN_USER rhn_pass=$RHN_PASS"

PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Install required support packages] ***************************************
changed: [localhost] => (item=[u'createrepo', u'dhcp', u'docker-1.7.1', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686'])

TASK [Install required pip-based support packages] *****************************
changed: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt)

TASK [Create the staging directories in /opt/autodeploy] ***********************
ok: [localhost] => (item=/opt/autodeploy/projects)
ok: [localhost] => (item=/opt/autodeploy/resources)

TASK [Create the resource directories in the staging directories] **************
changed: [localhost] => (item=docker)
changed: [localhost] => (item=ISO)
changed: [localhost] => (item=packages)
changed: [localhost] => (item=rpms)
changed: [localhost] => (item=scaleio)

TASK [Clone the project repos from Git] ****************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/dcaf-bada.git', u'name': u'dcaf-bada'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [Checkout the latest tagged version] **************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/dcaf-bada.git', u'name': u'dcaf-bada'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO]
ok: [localhost]

TASK [Download the Hanlon microkernel image to /opt/autodeploy/resources/ISO] **
changed: [localhost]

TASK [Check if RHEL DVD ISO file exists in /opt/autodeploy/resources/ISO] ******
ok: [localhost]

TASK [Find the RHEL DVD ISO file url] ******************************************
ok: [localhost]

TASK [Download the RHEL DVD ISO file to /opt/autodeploy/resources/ISO] *********
changed: [localhost]

TASK [Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]

TASK [Find the Red Hat KVM Guest Image file url] *******************************
ok: [localhost]

TASK [Download the KVM Guest Image file to /opt/autodeploy/resources/ISO] ******
changed: [localhost]

TASK [Download the EPEL RPMs to /opt/autodeploy/resources/rpms when offline] ***
skipping: [localhost]

TASK [Download the Red Hat RPMs to /opt/autodeploy/resources/rpms when offline]
skipping: [localhost]

TASK [Create the local repository in /opt/autodeploy/resources/rpms when offline] ***
skipping: [localhost]

TASK [Check if docker-py files exist in /opt/autodeploy/resources/packages] ****
ok: [localhost]

TASK [Mirror pip dependencies to /opt/autodeploy/resources/packages when offline] ***
skipping: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt)

TASK [Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages] ***
ok: [localhost]

TASK [Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages when offline] ***
skipping: [localhost]

TASK [Start and enable the docker service] *************************************
changed: [localhost]

TASK [Check if Docker image files exist in /opt/autodeploy/resources/docker] ***
ok: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
ok: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
ok: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Pull the project docker images from the docker registry] *****************
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

TASK [Save docker container images to /opt/autodeploy/resources/docker (Offline)] ***
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

TASK [Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio] *******
ok: [localhost]

TASK [Download ScaleIO files for ansible-scaleio to /opt/autodeploy/resources/scaleio] ***
changed: [localhost]

TASK [Copy the downloaded projects to the usb drive when offline] **************
skipping: [localhost] => (item=ansible-scaleio)
skipping: [localhost] => (item=dcaf-abe)
skipping: [localhost] => (item=slimer)
skipping: [localhost] => (item=dcaf-bada)

TASK [Copy the downloaded resources to the usb drive when offline] *************
skipping: [localhost] => (item=docker)
skipping: [localhost] => (item=ISO)
skipping: [localhost] => (item=packages)
skipping: [localhost] => (item=rpms)
skipping: [localhost] => (item=scaleio)

PLAY RECAP *********************************************************************
localhost                  : ok=22   changed=11   unreachable=0    failed=0
```


```bash
⚡ root@piptest1  /opt/autodeploy/projects/dcaf-abe/ansible  ➦ 856fff2 ●  ansible-playbook main.yml -vvv --extra-vars "github_key_file=~/github.pem"
Using /opt/autodeploy/projects/dcaf-abe/ansible/ansible.cfg as config file
3 plays in main.yml

PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171970.42-217385614075399 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171970.42-217385614075399 )" )'
localhost PUT /tmp/tmpPT2tEu TO /root/.ansible/tmp/ansible-tmp-1456171970.42-217385614075399/setup
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1456171970.42-217385614075399/setup; rm -rf "/root/.ansible/tmp/ansible-tmp-1456171970.42-217385614075399/" > /dev/null 2>&1'
ok: [localhost]

TASK [base : Install required support packages] ********************************
task path: /opt/autodeploy/projects/dcaf-abe/ansible/roles/base/tasks/main.yml:4
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171971.69-209718308866026 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171971.69-209718308866026 )" )'
localhost PUT /tmp/tmpXeXX2G TO /root/.ansible/tmp/ansible-tmp-1456171971.69-209718308866026/yum
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python -tt /root/.ansible/tmp/ansible-tmp-1456171971.69-209718308866026/yum; rm -rf "/root/.ansible/tmp/ansible-tmp-1456171971.69-209718308866026/" > /dev/null 2>&1'
ok: [localhost] => (item=[u'createrepo', u'dhcp', u'docker-1.7.1', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686']) => {"changed": false, "invocation": {"module_args": {"conf_file": null, "disable_gpg_check": false, "disablerepo": null, "enablerepo": null, "exclude": null, "install_repoquery": true, "list": null, "name": ["createrepo", "dhcp", "docker-1.7.1", "firefox", "genisoimage", "httpd", "ipmitool", "iptables-services", "ntp", "python-netaddr", "python-passlib", "python-pip", "python-xvfbwrapper", "sshpass", "unzip", "vim", "wget", "xorg-x11-server-Xvfb", "yum-utils", "openssl-devel", "glibc.i686"], "state": "present", "update_cache": false}, "module_name": "yum"}, "item": ["createrepo", "dhcp", "docker-1.7.1", "firefox", "genisoimage", "httpd", "ipmitool", "iptables-services", "ntp", "python-netaddr", "python-passlib", "python-pip", "python-xvfbwrapper", "sshpass", "unzip", "vim", "wget", "xorg-x11-server-Xvfb", "yum-utils", "openssl-devel", "glibc.i686"], "msg": "", "rc": 0, "results": ["createrepo-0.9.9-25.el7_2.noarch providing createrepo is already installed", "dhcp-12:4.2.5-42.el7.x86_64 providing dhcp is already installed", "docker-1.7.1-115.el7.x86_64 providing docker-1.7.1 is already installed", "firefox-38.6.1-1.el7_2.x86_64 providing firefox is already installed", "genisoimage-1.1.11-23.el7.x86_64 providing genisoimage is already installed", "httpd-2.4.6-40.el7.x86_64 providing httpd is already installed", "ipmitool-1.8.13-8.el7_1.x86_64 providing ipmitool is already installed", "iptables-services-1.4.21-16.el7.x86_64 providing iptables-services is already installed", "ntp-4.2.6p5-22.el7_2.1.x86_64 providing ntp is already installed", "python-netaddr-0.7.12-1.el7ost.noarch providing python-netaddr is already installed", "python-passlib-1.6.2-2.el7.noarch providing python-passlib is already installed", "python-pip-7.1.0-1.el7.noarch providing python-pip is already installed", "python-xvfbwrapper-0.2.4-2.el7.noarch providing python-xvfbwrapper is already installed", "sshpass-1.05-5.el7.x86_64 providing sshpass is already installed", "unzip-6.0-15.el7.x86_64 providing unzip is already installed", "vim-enhanced-2:7.4.160-1.el7.x86_64 providing vim is already installed", "wget-1.14-10.el7_0.1.x86_64 providing wget is already installed", "xorg-x11-server-Xvfb-1.17.2-10.el7.x86_64 providing xorg-x11-server-Xvfb is already installed", "yum-utils-1.1.31-34.el7.noarch providing yum-utils is already installed", "openssl-devel-1:1.0.1e-51.el7_2.2.x86_64 providing openssl-devel is already installed", "glibc-2.17-106.el7_2.4.i686 providing glibc.i686 is already installed"]}

TASK [base : Install required pip-based support packages (Online)] *************
task path: /opt/autodeploy/projects/dcaf-abe/ansible/roles/base/tasks/main.yml:10
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171973.56-140764807508726 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1456171973.56-140764807508726 )" )'
localhost PUT /tmp/tmp07gVrv TO /root/.ansible/tmp/ansible-tmp-1456171973.56-140764807508726/pip
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1456171973.56-140764807508726/pip; rm -rf "/root/.ansible/tmp/ansible-tmp-1456171973.56-140764807508726/" > /dev/null 2>&1'
ok: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt) => {"changed": false, "cmd": "/usr/bin/pip install --upgrade -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt", "invocation": {"module_args": {"chdir": null, "editable": true, "executable": null, "extra_args": "--upgrade", "name": null, "requirements": "/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt", "state": "present", "use_mirrors": true, "version": null, "virtualenv": null, "virtualenv_command": "virtualenv", "virtualenv_python": null, "virtualenv_site_packages": false}, "module_name": "pip"}, "item": "/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt", "name": null, "requirements": "/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt", "state": "present", "stderr": "", "stdout": "Requirement already up-to-date: docker-py==1.4.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 2))\nRequirement already up-to-date: requests==2.8.1 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 3))\nRequirement already up-to-date: six==1.10.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 4))\nRequirement already up-to-date: websocket-client==0.34.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 5))\nRequirement already up-to-date: backports.ssl-match-hostname==3.4.0.2 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 6))\nRequirement already up-to-date: pip2pi==0.6.8 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 9))\nRequirement already up-to-date: selenium==2.48.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 10))\nRequirement already up-to-date: pyvmomi==5.5.0-2014.1.1 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 11))\nRequirement already up-to-date: pip>=1.1 in /usr/lib/python2.7/site-packages (from pip2pi==0.6.8->-r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 9))\n", "stdout_lines": ["Requirement already up-to-date: docker-py==1.4.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 2))", "Requirement already up-to-date: requests==2.8.1 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 3))", "Requirement already up-to-date: six==1.10.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 4))", "Requirement already up-to-date: websocket-client==0.34.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 5))", "Requirement already up-to-date: backports.ssl-match-hostname==3.4.0.2 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 6))", "Requirement already up-to-date: pip2pi==0.6.8 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 9))", "Requirement already up-to-date: selenium==2.48.0 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 10))", "Requirement already up-to-date: pyvmomi==5.5.0-2014.1.1 in /usr/lib/python2.7/site-packages (from -r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 11))", "Requirement already up-to-date: pip>=1.1 in /usr/lib/python2.7/site-packages (from pip2pi==0.6.8->-r /opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt (line 9))"], "version": null, "virtualenv": null}

TASK [base : Install required pip-based support packages (Offline)] ************
task path: /opt/autodeploy/projects/dcaf-abe/ansible/roles/base/tasks/main.yml:18
skipping: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt)  => {"changed": false, "item": "/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt", "skip_reason": "Conditional check failed", "skipped": true}

```
