### PR TITLE
Changes for docker version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 
 install:
   # Install Ansible.
-  - pip install ansible==1.9.4
+  - pip install ansible
 
 script:
   - cd ansible && python travis_parse_yaml.py

--- a/ansible/files/pip-requirements.txt
+++ b/ansible/files/pip-requirements.txt
@@ -1,9 +1,5 @@
 ## docker-py and dependencies
-docker-py==1.4.0
-requests==2.8.1
-six==1.10.0
-websocket-client==0.34.0
-backports.ssl-match-hostname==3.4.0.2
+docker-py
 
 ## Other requirements
 pip2pi==0.6.8

--- a/ansible/files/rhn_rpm_packages.txt
+++ b/ansible/files/rhn_rpm_packages.txt
@@ -4,7 +4,7 @@ bridge-utils
 ceph-common
 createrepo
 dhcp
-docker-1.7.1
+docker
 fence-agents-all
 firefox
 genisoimage

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -12,9 +12,8 @@ use_dcaf-bada: true
 
 # Autodeploy common vars
 autodeploy_base_path: /opt/autodeploy
-docker_api_version: 1.18
+docker_api_version: "1.20"
 docker_path: "{{ resources_base_path }}/docker/"
-docker_py_zip: docker-py-1.4.0.tar.gz
 iso_path: "{{ resources_base_path }}/ISO/"
 packages_path: "{{ resources_base_path }}/packages/"
 projects_base_path: "{{ autodeploy_base_path }}/projects"
@@ -51,7 +50,7 @@ usb_resources_path: "{{ usb_hdd }}/autodeploy/resources"
 autodeploy_support_pkgs:
   - createrepo
   - dhcp
-  - docker-1.7.1
+  - docker
   - firefox
   - genisoimage
   - httpd

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -6,7 +6,6 @@
     docker_network: "{{ ansible_docker0.ipv4.network }}"
     local_network: "{{ ansible_default_ipv4.network }}"
     hanlon_subnets: "{{ local_network }}/24,{{ docker_network }}/16"
-    docker_api_version: 1.18
 
   tasks:
     - name: Clean up existing containers

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -157,17 +157,16 @@
       when: offline
       tags: repo
 
-    - name: Check if docker-py files exist in /opt/autodeploy/resources/packages
-      stat:
-        path: "{{ packages_path }}/{{ docker_py_zip }}"
-      register: docker_py
-      tags: docker
+    - name: Check if files exist in packages folder
+      find:
+        path: "{{ packages_path }}"
+      register: packages_files
+      when: offline
 
     - name: Mirror pip dependencies to /opt/autodeploy/resources/packages when offline
-      command: pip2tgz {{ packages_path }} -r {{ item }} 
-      when: offline and not (docker_py.stat.exists)
+      command: pip2tgz {{ packages_path }} -r {{ item }}
+      when: offline and packages_files.matched == 0
       with_fileglob: "files/*pip-requirements*"
-      
 
     - name: Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages
       stat:


### PR DESCRIPTION
With the move to Ansible v2, the project is no longer limited by support of a specific version of docker.  This pull request updates the project to use the latest version of docker and docker-py.  The Docker API version still needs to be set to a specific version due to the fact that the default Docker API version set in docker-py is higher than the version available for the docker package.

* docker.x86_64    1.8.2-10.el7      rhel-7-server-extras-rpms => Docker 1.8.x API version = 1.20
* docker-py 1.7.1 => default Docker API version = 1.21 (Docker 1.9.x)

Additionally, the `docker_api_version` variable must be quoted or `1.20` will be transformed to `1.2`, and will not function properly.

Due to the version change of docker-py, the check for pip dependencies has been updated to no longer require a specific file to be present.

Testing stage_resource.yml:
```
[root@rhel72 ansible]# git checkout mtnbikenc/NGA-602
Previous HEAD position was 73b0afb... Merge pull request #76 from mtnbikenc/NGA-604
HEAD is now at ea3a3b4... Changes for docker version update
[root@rhel72 ansible]# ansible-playbook stage_resources.yml --extra-vars "github_key_file=~/github.pem rhn_user=$RHN_USER rhn_pass=$RHN_PASS offline=true"

PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Install required support packages] ***************************************
changed: [localhost] => (item=[u'createrepo', u'dhcp', u'docker', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686'])

TASK [Install required pip-based support packages] *****************************
changed: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt)

< ... snip ... >

TASK [Create the local repository in /opt/autodeploy/resources/rpms when offline] ***
changed: [localhost]

TASK [Check if files exist in packages folder] *********************************
ok: [localhost]

TASK [Mirror pip dependencies to /opt/autodeploy/resources/packages when offline] ***
changed: [localhost] => (item=/opt/autodeploy/projects/dcaf-abe/ansible/files/pip-requirements.txt)

TASK [Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages] ***
ok: [localhost]

TASK [Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages when offline] ***
changed: [localhost]

TASK [Start and enable the docker service] *************************************
changed: [localhost]

TASK [Check if Docker image files exist in /opt/autodeploy/resources/docker] ***
ok: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
ok: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
ok: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Pull the project docker images from the docker registry] *****************
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

TASK [Save docker container images to /opt/autodeploy/resources/docker (Offline)] ***
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

< ... snip ... >

PLAY RECAP *********************************************************************
localhost                  : ok=32   changed=20   unreachable=0    failed=0
```

Testing main.yml:
```
[root@rhel72 ansible]# ansible-playbook main.yml --extra-vars "github_key_file=~/github.pem"

PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [base : Install required support packages] ********************************
ok: [localhost] => (item=[u'createrepo', u'dhcp', u'docker', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686'])

< ... snip ... >

PLAY [Start Hanlon Docker Environment] *****************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Clean up existing containers] ********************************************
changed: [localhost] => (item={u'image': u'mongo', u'name': u'hanlon-mongo'})
changed: [localhost] => (item={u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
changed: [localhost] => (item={u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Load Mongo, Hanlon and Atftpd Containers (Offline)] **********************
skipping: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Start Mongo Container] ***************************************************
changed: [localhost]

TASK [Remove hanlon client config file] ****************************************
ok: [localhost]

TASK [Start Hanlon Server Container] *******************************************
changed: [localhost]

TASK [Wait for Hanlon Server to start] *****************************************
FAILED - RETRYING: TASK: Wait for Hanlon Server to start (2 retries left). Result was: {'invocation': {'module_name': u'uri', u'module_args': {u'directory_mode': None, u'force': None, u'remote_src': None, u'follow_redirects': u'safe', u'follow': False, u'owner': None, u'body_format': u'raw', u'group': None, u'serole': None, u'content': None, u'setype': None, u'status_code': [200], u'return_content': True, u'method': u'GET', u'body': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'user': None, u'regexp': None, u'password': None, u'src': None, u'url': u'http://10.0.10.4:8026/hanlon/api/v1/config/ipxe', u'backup': None, u'seuser': None, u'creates': None, u'delimiter': None, u'mode': None, u'timeout': 30, u'validate_certs': True}}, u'msg': u'Socket error: [Errno 111] Connection refused to http://10.0.10.4:8026/hanlon/api/v1/config/ipxe', u'failed': True}
ok: [localhost]

TASK [Start TFTP Server Container] *********************************************
changed: [localhost]

PLAY [Configure deployment node for site discovery] ****************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [dhcp-server : install dhcp server package] *******************************
ok: [localhost]

TASK [dhcp-server : Configure dhcpd.conf] **************************************
changed: [localhost]

TASK [dhcp-server : Configure ipxe.conf] ***************************************
changed: [localhost]

TASK [dhcp-server : Copy ipxe-option-space.conf] *******************************
changed: [localhost]

TASK [dhcp-server : enable dhcpd service] **************************************
changed: [localhost]

TASK [Check for local copy of Hanlon Microkernel] ******************************
ok: [localhost]

TASK [Download Hanlon Microkernel (Online)] ************************************
changed: [localhost]

TASK [Copy Hanlon Microkernel to /opt/hanlon/image (Offline)] ******************
skipping: [localhost]

TASK [Add a Microkernel Image to Hanlon] ***************************************
changed: [localhost]

TASK [Add a Discover Only Model to Hanlon] *************************************
changed: [localhost]

TASK [Add a Discover Only Policy to Hanlon] ************************************
changed: [localhost]

RUNNING HANDLER [dhcp-server : restart dhcpd] **********************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=51   changed=36   unreachable=0    failed=0
```




