### PR TITLE
Updating method to download Ansible dependencies

### DIFF
--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -137,10 +137,16 @@
       when: offline
       tags: repo
 
+    - name: Find Ansible RPM dependencies
+      shell: yum deplist {{ item }} | grep provider | awk '{print $2}' | sort | uniq
+      with_fileglob: ~/ansible/rpm-build/ansible-*.noarch.rpm
+      register: ansible_deps
+      when: offline
+      tags: repo
+
     - name: Download the Ansible dependent RPMs when offline
       shell: repotrack "{{ item }}" -p "{{ rpm_path }}"
-      ignore_errors: yes
-      with_fileglob: ~/ansible/rpm-build/ansible-*.noarch.rpm
+      with_items: "{{ ansible_deps.results[0].stdout_lines }}"
       when: offline
       tags: repo
 


### PR DESCRIPTION
A bug was discovered in the task where the RPM dependencies for the self-created Ansible RPM are downloaded.  `repotrack` does not support specifying an RPM.

Testing:
```
  TASK [Find Ansible RPM dependencies] *******************************************
  changed: [localhost] => (item=/root/ansible/rpm-build/ansible-2.0.1.0-0.git201602242329.bb6cade.HEAD.el7.noarch.rpm)

  TASK [Download the Ansible dependent RPMs when offline] ************************
  changed: [localhost] => (item=python-httplib2.noarch)
  changed: [localhost] => (item=python-jinja2.noarch)
  changed: [localhost] => (item=python-keyczar.noarch)
  changed: [localhost] => (item=python-paramiko.noarch)
  changed: [localhost] => (item=python-setuptools.noarch)
  changed: [localhost] => (item=python-six.noarch)
  changed: [localhost] => (item=python.x86_64)
  changed: [localhost] => (item=PyYAML.x86_64)
  changed: [localhost] => (item=sshpass.x86_64)
```